### PR TITLE
Fully qualify image sources.

### DIFF
--- a/examples/caprover-one-click-app.yml
+++ b/examples/caprover-one-click-app.yml
@@ -1,7 +1,7 @@
 captainVersion: 4
 services:
     $$cap_appname-redis:
-        image: redis:$$cap_redis_version
+        image: docker.io/library/redis:$$cap_redis_version
         container_name: $$cap_appname-redis
         restart: always
         caproverExtra:

--- a/examples/digitalocean-1click/docker-compose.yml
+++ b/examples/digitalocean-1click/docker-compose.yml
@@ -41,12 +41,12 @@ services:
     command: celery -A gramps_webapi.celery worker --loglevel=INFO
 
   grampsweb_redis:
-    image: redis:7.2.4-alpine
+    image: docker.io/library/redis:7.2.4-alpine
     container_name: grampsweb_redis
     restart: always
 
   proxy:
-    image: nginxproxy/nginx-proxy
+    image: docker.io/nginxproxy/nginx-proxy
     container_name: nginx-proxy
     restart: always
     ports:
@@ -66,7 +66,7 @@ services:
       - proxy-tier
 
   acme-companion:
-    image: nginxproxy/acme-companion
+    image: docker.io/nginxproxy/acme-companion
     container_name: nginx-proxy-acme
     restart: always
     environment:

--- a/examples/docker-compose-base/docker-compose.yml
+++ b/examples/docker-compose-base/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     command: celery -A gramps_webapi.celery worker --loglevel=INFO
 
   grampsweb_redis:
-    image: redis:7.2.4-alpine
+    image: docker.io/library/redis:7.2.4-alpine
     container_name: grampsweb_redis
     restart: always
 

--- a/examples/docker-compose-letsencrypt/docker-compose.yml
+++ b/examples/docker-compose-letsencrypt/docker-compose.yml
@@ -42,12 +42,12 @@ services:
     command: celery -A gramps_webapi.celery worker --loglevel=INFO
 
   grampsweb_redis:
-    image: redis:7.2.4-alpine
+    image: docker.io/library/redis:7.2.4-alpine
     container_name: grampsweb_redis
     restart: always
 
   proxy:
-    image: nginxproxy/nginx-proxy
+    image: docker.io/nginxproxy/nginx-proxy
     container_name: nginx-proxy
     restart: always
     ports:
@@ -67,7 +67,7 @@ services:
       - proxy-tier
 
   acme-companion:
-    image: nginxproxy/acme-companion
+    image: docker.io/nginxproxy/acme-companion
     container_name: nginx-proxy-acme
     restart: always
     environment:


### PR DESCRIPTION
This makes default configuration of `podman-compose` in Debian/Arch (possibly other distros too) happy and has no negative effect on `docker-compose`.