### PR TITLE
prefer docker compose v2

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -35,7 +35,7 @@ If you plan to use Gramps Web only on your local network, you can skip this step
 Run
 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 
 On first run, the app will display a first-run wizard that will allow you to

--- a/docs/Postgres.md
+++ b/docs/Postgres.md
@@ -29,7 +29,7 @@ Again, if you have set up the PostgreSQL server yourself, you can follow the [in
 Alternatively, if you have followed the Docker Compose instructions above, you can use the following command to import a Gramps XML file located on your docker host:
 
 ```bash
-docker-compose run --entrypoint "" grampsweb \
+docker compose run --entrypoint "" grampsweb \
     gramps -C postgres \
     -i /root/.gramps/grampsdb/my_tree.gramps \
     --config=database.backend:postgresql \
@@ -44,7 +44,7 @@ To configure Web API for use with the PostgreSQL database, add the following und
 
 ```yaml
       # the PostgreSQL addon assumes the tree name to be
-      # equal to the database name and here the default 
+      # equal to the database name and here the default
       # database name of the PostgreSQL image is used
       TREE: postgres
       # The credentials must agree with the ones used for
@@ -79,8 +79,8 @@ postgresql://gramps:postgres_password_gramps@postgres_gramps:5432/gramps
 In case of issues, please monitor the log output of Gramps Web and the PostgreSQL server. In the case of docker, this is achieved with
 
 ```
-docker-compose logs grampsweb
-docker-compose logs postgres_grampsweb
+docker compose logs grampsweb
+docker compose logs postgres_grampsweb
 ```
 
 If you suspect there is an issue with Gramps Web (or the documentation), please file an issue [on Github](https://github.com/gramps-project/gramps-web-api/issues).

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -3,8 +3,8 @@
 If you are using one of the installation methods based on Docker Compose, updating Gramps Web to the latest version is simple. In the folder where your `docker-compose.yml` is located, run the following commands
 
 ```bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 For minor version jumps of [Gramps Web API](https://github.com/gramps-project/gramps-web-api), this is all that is needed. Do follow the [release notes of Gramps Web API](https://github.com/gramps-project/gramps-web-api/releases) though, as there could be breaking changes that require additional attention or configuration changes.

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -24,14 +24,14 @@ There are two ways to manage users:
 - With owner permissions using the web interface
 - On the command line on the server
 
-The owner account required to first access the web app can be added in the onboarding wizard that is automatically launched when accessing Gramps Web with an empty user database. 
+The owner account required to first access the web app can be added in the onboarding wizard that is automatically launched when accessing Gramps Web with an empty user database.
 
 ### Managing users on the command line
 
 When using [Docker Compose](Deployment.md), the basic command is
 
 ```bash
-docker-compose run grampsweb python3 -m gramps_webapi user COMMAND [ARGS]
+docker compose run grampsweb python3 -m gramps_webapi user COMMAND [ARGS]
 ```
 
 The `COMMAND` can be `add` or `delete`. Use `--help` for `[ARGS]` to show the syntax and possible configuration options.

--- a/docs/dev-frontend/setup.md
+++ b/docs/dev-frontend/setup.md
@@ -13,7 +13,7 @@ cd gramps-web
 To build and start the containers running the Gramps Web backend with the Gramps example database, as well as the frontend in development mode, simply run
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Options for logging in are: owner, editor, contributor, guest or member (use same word for both username and password).
@@ -32,10 +32,10 @@ Once you make changes to the frontend code, you browser will be reloaded automat
 The installed git hooks will format and lint the code on every commit. You can run the scripts manually using
 
 ```
-docker-compose run gramps-frontend format
+docker compose run gramps-frontend format
 ```
 and
 ```
-docker-compose run gramps-frontend lint
+docker compose run gramps-frontend lint
 ```
 respectively.

--- a/examples/digitalocean-1click/docker-compose.yml
+++ b/examples/digitalocean-1click/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   grampsweb: &grampsweb
     container_name: grampsweb

--- a/examples/digitalocean-1click/firstlogin.sh
+++ b/examples/digitalocean-1click/firstlogin.sh
@@ -7,4 +7,4 @@
 cp -f /etc/skel/.bashrc /root/.bashrc
 
 # start services using docker-compose
-(cd /opt/grampsweb && docker-compose pull && docker-compose stop && docker-compose up --remove-orphans -d)
+(cd /opt/grampsweb && docker compose pull && docker compose stop && docker compose up --remove-orphans -d)

--- a/examples/digitalocean-1click/install_grampsweb.sh
+++ b/examples/digitalocean-1click/install_grampsweb.sh
@@ -23,7 +23,7 @@ apt-get -qq install --no-install-recommends apt-transport-https ca-certificates 
 # install docker if needed
 if ! command -v docker &> /dev/null; then
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/download.docker.com.gpg
-  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable"
   apt-get update
   apt-get -qq install docker-ce
 fi
@@ -31,7 +31,7 @@ fi
 # install docker-compose if needed
 if ! command -v docker-compose &> /dev/null; then
   apt-get update
-  apt-get -qq install docker-compose
+  apt-get -qq install docker-compose-plugin
 fi
 
 # create user

--- a/examples/docker-compose-base/docker-compose.yml
+++ b/examples/docker-compose-base/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   grampsweb: &grampsweb
     image: ghcr.io/gramps-project/grampsweb:latest

--- a/examples/docker-compose-letsencrypt/docker-compose.yml
+++ b/examples/docker-compose-letsencrypt/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   grampsweb: &grampsweb
     container_name: grampsweb


### PR DESCRIPTION
Docker has released Compose v2 since 2020, and is now the default in the Docker repository. Since July 2023 Compose v1 has stopped receiving updates:

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
> 
> Compose V2, which was first released in 2020, is included with all currently supported versions of Docker Desktop. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.
> 
> The final Compose V1 release, version 1.29.2, was May 10, 2021. These packages haven't received any security updates since then. Use at your own risk.
> https://docs.docker.com/compose/migrate/).

Compose V2 ignores the **version** top-level element in the compose `.yml` file.

This PR migrates to Docker compose v2 by:
1) installing the `docker-compose-plugin` package provided by Docker repository
2) removing the now ignored **version** top-level element in compose `.yml` files
3) using the `docker compose` command in place of the `docker-compose` command (`docker-compose` is now an alias of `docker compose` so we can still check if the `docker-compose` command exists before attempting to install the `docker-compose-plugin` package)