### PR TITLE
Improve docs for using Ollama as LLM provider; fix typos in various files

### DIFF
--- a/docs/administration/import.md
+++ b/docs/administration/import.md
@@ -30,4 +30,4 @@ It expects a ZIP file with the missing media files inside. The folder structure 
 
 Note that this feature only works for files that have the correct checksum in the Gramps database (which should be ensured by running the check and repair tool in the first step).
 
-When moving to Gramps Web from a different genalogy program including media files, it is recommended to first import everything into Gramps Desktop, which has more options to associate existing media files with an imported tree.
+When moving to Gramps Web from a different genealogy program including media files, it is recommended to first import everything into Gramps Desktop, which has more options to associate existing media files with an imported tree.

--- a/docs/administration/owner.md
+++ b/docs/administration/owner.md
@@ -20,7 +20,7 @@ However, the owner creation form will not be displayed automatically on the Gram
 
 A possible workflow for a site administrator to create a new tree is to
 
-- Create a tree via the REST API, obtaing the tree ID of the new tree
+- Create a tree via the REST API, obtaining the tree ID of the new tree
 - Share the link to the owner creation form with the appropriate tree ID with the prospective tree owner
 
 The tree owner creation form is analogous to the admin creation form described above, except that it does not allow to change the e-mail configuration (which is only allowed for admins).

--- a/docs/administration/sync.md
+++ b/docs/administration/sync.md
@@ -23,7 +23,7 @@ Optional step:
 
 ## Usage
 
-Once installed, the addon is availabe in Gramps under *Tools > Family Tree Processing > Gramps&nbsp;Web&nbsp;Sync*. Once started, and after confirming the dialog that the undo history will be discarded, the tool will ask you for the base URL (example: `https://mygrampsweb.com/`) of your Gramps Web instance, your username, and password. You need an account with owner privileges To sync changes back to your remote database. The username and URL will be stored in plain text in your Gramps user directory, the password will only be stored if `keyring` is installed (see above).
+Once installed, the addon is available in Gramps under *Tools > Family Tree Processing > Gramps&nbsp;Web&nbsp;Sync*. Once started, and after confirming the dialog that the undo history will be discarded, the tool will ask you for the base URL (example: `https://mygrampsweb.com/`) of your Gramps Web instance, your username, and password. You need an account with owner privileges To sync changes back to your remote database. The username and URL will be stored in plain text in your Gramps user directory, the password will only be stored if `keyring` is installed (see above).
 
 If there are any changes, the tool will display a confirmation dialog before applying the changes. (At present, the confirmation dialog only shows the Gramps IDs of the affected objects.)
 
@@ -57,4 +57,4 @@ The principles of operation of the tool are very simple:
 - If an object is different but changed after **t** only in one database, sync to the other one (assume modified object)
 - If an object is different but changed after **t** in both databases, merge them (assume conflicting modification)
 
-This algorithm is simple and robust as it does not require tracking syncrhonization history. However, it works best when you *synchronize often*.
+This algorithm is simple and robust as it does not require tracking synchronization history. However, it works best when you *synchronize often*.

--- a/docs/development/backend/setup.md
+++ b/docs/development/backend/setup.md
@@ -91,7 +91,7 @@ Run
 ```
 python3 -m gramps_webapi --config path/to/config run
 ```
-The API will be accesible at `http://127.0.0.1:5000` by default, which displays an empty page.  Access your Gramps data using the API described by [gramps-project.github.io/gramps-web-api](https://gramps-project.github.io/gramps-web-api/). For example, to show people go to `http://127.0.0.1:5000/api/people`
+The API will be accessible at `http://127.0.0.1:5000` by default, which displays an empty page.  Access your Gramps data using the API described by [gramps-project.github.io/gramps-web-api](https://gramps-project.github.io/gramps-web-api/). For example, to show people go to `http://127.0.0.1:5000/api/people`
 
 #### Options
 

--- a/docs/install_setup/chat.md
+++ b/docs/install_setup/chat.md
@@ -1,14 +1,14 @@
-# Settung up AI chat
+# Setting up AI chat
 
 !!! info
     AI chat requires Gramps Web API version 2.5.0 or higher.
 
 
-Gramps Web API supports asking questions about the genealogical database using large language modes (LLM) via a technique called reasearch augmented generation (RAG).
+Gramps Web API supports asking questions about the genealogical database using large language models (LLM) via a technique called retrieval-augmented generation (RAG).
 
 RAG works as follows. First, a *vector embedding model* is used to create an index of all objects in the Gramps database in the form of numerical vectors that encode the objects' meaning. This process is similar to the creation of the full-text search index, but more computationally expensive.
 
-Next, when a user asks a question via the chat enpoint, that question is converted to a vector as well, by the same embedding model,  and compared the objects in the Gramps database. This *semantic search* will return objects in the database that are most semantically similar to the question.
+Next, when a user asks a question via the chat endpoint, that question is converted to a vector as well, by the same embedding model,  and compared the objects in the Gramps database. This *semantic search* will return objects in the database that are most semantically similar to the question.
 
 In the final step, the question and the retrieved objects are sent to an LLM to formulate an answer based on the provided information. In this way, the chatbot has access to detailed information about the contents of the genealogical database instead of relying solely on pre-existing knowledge.
 
@@ -18,7 +18,7 @@ To enable the chat endpoint in Gramps Web API, three steps are necessary:
 2. Enabling semantic search,
 3. Setting up an LLM provider.
 
-The three step are described below in turn.
+The three step are described below in turn. Finally, an owner or administrator must [configure which users can access the chat feature](users.md#configuring-who-can-use-ai-chat) in the Manage Users settings.
 
 ## Installing required dependencies
 
@@ -57,7 +57,7 @@ Please share learnings about different models with the community!
 
 ## Setting up an LLM provider
 
-Communication with the LLM uses an OpenAI compatible API using the `openai-python` library. This allows using a locally deployed LLM via Ollama (see [Ollama OpenAI compatibility](https://ollama.com/blog/openai-compatibility)) or an API like OpenAI or Huggingface TGI. The LLM is configured via the configuration parameters `LLM_MODEL` and `LLM_BASE_URL`.
+Communication with the LLM uses an OpenAI compatible API using the `openai-python` library. This allows using a locally deployed LLM via Ollama (see [Ollama OpenAI compatibility](https://ollama.com/blog/openai-compatibility)) or an API like OpenAI or Hugging Face TGI (Text Generation Inference). The LLM is configured via the configuration parameters `LLM_MODEL` and `LLM_BASE_URL`.
 
 
 ### Using a hosted LLM via the OpenAI API
@@ -84,7 +84,7 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      ollama_data:/root/.ollama
+      - ollama_data:/root/.ollama
 
 volumes:
     ollama_data:

--- a/docs/install_setup/frontend-config.md
+++ b/docs/install_setup/frontend-config.md
@@ -1,6 +1,6 @@
 # Customizing the frontend
 
-The Gramps Web frontend is a Javascript application that is deployed as a set of static HTML, CSS, and Javascript files. Normally, no special configuration is necessary for the frontend. However, some behaviour can be changed by setting appropriate options in the `config.js` file at the root of the distriubtion.
+The Gramps Web frontend is a Javascript application that is deployed as a set of static HTML, CSS, and Javascript files. Normally, no special configuration is necessary for the frontend. However, some behaviour can be changed by setting appropriate options in the `config.js` file at the root of the distribution.
 
 The file should have the following structure:
 

--- a/docs/install_setup/users.md
+++ b/docs/install_setup/users.md
@@ -17,6 +17,10 @@ Admin | 5 | Owner + edit other trees in multi-tree setup
 
 \* Note that the "Contributor" role is currently only partially supported; e.g., family objects cannot be added since they imply a modification of the underlying Gramps person objects of family members. It is recommended to use the other roles whenever possible.
 
+## Configuring who can use AI chat
+
+If you have [configured AI chat](chat.md), you will see an option here to choose which user groups are allowed to use the chat feature.
+
 ## Managing users
 
 There are two ways to manage users:

--- a/docs/user-guide/blog.md
+++ b/docs/user-guide/blog.md
@@ -2,11 +2,11 @@
 
 The blog is meant for presenting stories about your family history research.
 
-In the Gramps database, blog posts are represented as sources with a note attached, containg the blog's text, and optionally, media files for the images of the blog post. Gramps Web treats every source with a tag `Blog` as blog article.
+In the Gramps database, blog posts are represented as sources with a note attached, containing the blog's text, and optionally, media files for the images of the blog post. Gramps Web treats every source with a tag `Blog` as blog article.
 
 ## Add a blog post
 
-To add a blog post, you can use Gramps Web or Gramps Dekstop ([synchronized](../administration/sync.md) with Gramps Web), the steps are the same in both cases:
+To add a blog post, you can use Gramps Web or Gramps Desktop ([synchronized](../administration/sync.md) with Gramps Web), the steps are the same in both cases:
 
 - Add a new source. The title of the source will be the title of your blog post, the author of the source will be the author of the post.
 - Optionally, associate the source with a repository corresponding to your Gramps Web blog


### PR DESCRIPTION
Separate commits for easier review:

1. Improve docs for using Ollama as LLM provider
    1. Correct a typo in the Ollama data volume configuration
    2. Add step to configure user groups who can access chat
    3. Fix typos

3. Fix typos in various files