### PR TITLE
Fedora

### DIFF
--- a/docs/administration/sync.md
+++ b/docs/administration/sync.md
@@ -17,10 +17,14 @@ It is available in Gramps Desktop and can be installed [in the usual way](https:
 !!! warn
     Please make sure to use the same version of Gramps on your desktop as the one running on your server. See the [Get Help](../help/help.md) section for how to find out which Gramps version your server is running. The Gramps version has the form `MAJOR.MINOR.PATCH`, and `MAJOR` and `MINOR` must be the same on web and desktop.
 
-
 Optional step:
 
-- Install `keyring` (e.g. `sudo apt install python3-keyring`) to allow storing the API password safely in your system's password manager 
+- Install `keyring` (e.g. `sudo apt install python3-keyring` or `sudo dnf install python3-keyring`) to allow storing the API password safely in your system's password manager 
+
+??? note Gnome keyring bug
+    There is currently a [bug in python keyring](https://github.com/jaraco/keyring/issues/496) that affects many Gnome desktop configurations.  You may need to create the configuration file `~/.config/python_keyring/keyringrc.cfg` and edit it to look like this:
+        [backend]
+        default-keyring=keyring.backends.SecretService.Keyring
 
 ## Usage
 

--- a/docs/administration/sync.md
+++ b/docs/administration/sync.md
@@ -19,12 +19,13 @@ It is available in Gramps Desktop and can be installed [in the usual way](https:
 
 Optional step:
 
-- Install `keyring` (e.g. `sudo apt install python3-keyring` or `sudo dnf install python3-keyring`) to allow storing the API password safely in your system's password manager 
-
-??? note Gnome keyring bug
+??? note inline end "Gnome keyring bug"
     There is currently a [bug in python keyring](https://github.com/jaraco/keyring/issues/496) that affects many Gnome desktop configurations.  You may need to create the configuration file `~/.config/python_keyring/keyringrc.cfg` and edit it to look like this:
+
         [backend]
         default-keyring=keyring.backends.SecretService.Keyring
+
+- Install `keyring` (e.g. `sudo apt install python3-keyring` or `sudo dnf install python3-keyring`) to allow storing the API password safely in your system's password manager 
 
 ## Usage
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ plugins:
         'user-guide/sync.md': 'administration/sync.md'
 markdown_extensions:
   - admonition
+  - pymdownx.details
   - pymdownx.highlight
   - pymdownx.superfences
   - attr_list


### PR DESCRIPTION
Added the details extension for admonitions to the mkdocs yml installation to allow notes that apply to only a few to be collapsed and less intrusive.

Added a collapsed note about a bug in python keyring that affects some Gnome configurations to the optional password saving installation note in sync.md