### PR TITLE
Remove nginx_proxy.conf volume from docker-compose

### DIFF
--- a/examples/docker-compose-letsencrypt/docker-compose.yml
+++ b/examples/docker-compose-letsencrypt/docker-compose.yml
@@ -54,7 +54,6 @@ services:
     environment:
       ENABLE_IPV6: "true"
     volumes:
-      - ./nginx_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro
       - conf:/etc/nginx/conf.d
       - dhparam:/etc/nginx/dhparam
       - certs:/etc/nginx/certs:ro


### PR DESCRIPTION
Solves the issue with: 

```
nginx.1     | 2025/09/23 09:19:18 [crit] 1413#1413: pread() "/etc/nginx/conf.d/my_proxy.conf" failed (21: Is a directory)
nginx.1     | nginx: [crit] pread() "/etc/nginx/conf.d/my_proxy.conf" failed (21: Is a directory)
forego      | starting nginx.1 on port 141100
```