### PR TITLE
docs: add documentation for `hideDNALink`

### DIFF
--- a/docs/install_setup/frontend-config.md
+++ b/docs/install_setup/frontend-config.md
@@ -14,6 +14,7 @@ The following option keys exist.
 
 Key |Type | Description 
 ----|-----|-----------
+`hideDNALink` | boolean | If true, hide the DNA link on the navigation bar.
 `hideRegisterLink` | boolean | If true, hide the registration link on the login page. This should be used for multi-tree deployments.
 `loginRedirect` | string | URL to redirect to when not logged in and navigating to any page other than "login" or "register"
 `leafletTileUrl` | string | Custom tile URL for Leaflet maps


### PR DESCRIPTION
This adds documentation for https://github.com/gramps-project/gramps-web/pull/823