### PR TITLE
add: Keycloak setup docs

### DIFF
--- a/docs/da/install_setup/oidc.md
+++ b/docs/da/install_setup/oidc.md
@@ -203,3 +203,17 @@ OIDC_GITHUB_CLIENT_SECRET="your-github-client-secret"
 ### Authelia
 
 En fællesskabsoprettet OIDC opsætningsguide til Gramps Web er tilgængelig på [den officielle Authelia-dokumentationshjemmeside](https://www.authelia.com/integration/openid-connect/clients/gramps/).
+
+
+### Keycloak
+
+Most of the configuration for Keycloak can be left at its defaults (*Client → Create client → Client authentication ON*).
+
+There are a few exceptions:
+
+1. **OpenID scope** – The `openid` scope isn’t included by default in all Keycloak versions. To avoid issues, add it manually: *Client → [Gramps client] → Client scopes → Add scope → Name: `openid` → Set as default.*
+
+2. **Roles** – Roles can be assigned either at the client level or globally per realm.
+
+    * If you're using client roles, set the `OIDC_ROLE_CLAIM` config option to: `resource_access.[gramps-client-name].roles`
+    * To make roles visible to Gramps, navigate to *Client Scopes* (the top‑level section, not under the specific client), then: *Roles → Mappers → client roles → Add to userinfo → ON.*


### PR DESCRIPTION
To make Keycloak work with gramps there are a couple of settings changes that deviate from most common defaults  this points them out.