### PR TITLE
add external documentation for setup on synology nas

### DIFF
--- a/docs/da/install_setup/synology.md
+++ b/docs/da/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS Opsætning
+
+For at opsætte Gramps Web på en Synology NAS findes der en dedikeret gratis vejledning [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) af Bogdan Lixandru.
+

--- a/docs/de/install_setup/synology.md
+++ b/docs/de/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS Einrichtung
+
+Für die Einrichtung von Gramps Web auf einem Synology NAS gibt es ein kostenloses Tutorial [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) von Bogdan Lixandru.
+

--- a/docs/en/install_setup/synology.md
+++ b/docs/en/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS Setup
+
+For setting up Gramps Web on a Synology NAS there is a dedicated free tutorial [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) by Bogdan Lixandru.
+

--- a/docs/es/install_setup/synology.md
+++ b/docs/es/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Configuración de Synology NAS
+
+Para configurar Gramps Web en un Synology NAS, existe un tutorial gratuito dedicado [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) por Bogdan Lixandru.
+

--- a/docs/fi/install_setup/synology.md
+++ b/docs/fi/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS -asennus
+
+Gramps Webin asentamiseen Synology NAS -laitteelle on saatavilla ilmainen opas [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) tekijältä Bogdan Lixandru.
+

--- a/docs/fr/install_setup/synology.md
+++ b/docs/fr/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Configuration Synology NAS
+
+Pour configurer Gramps Web sur un Synology NAS, il existe un tutoriel gratuit dédié [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) par Bogdan Lixandru.
+

--- a/docs/it/install_setup/synology.md
+++ b/docs/it/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Configurazione Synology NAS
+
+Per configurare Gramps Web su un Synology NAS, esiste un tutorial gratuito dedicato [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) di Bogdan Lixandru.
+

--- a/docs/ja/install_setup/synology.md
+++ b/docs/ja/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS セットアップ
+
+Synology NAS に Gramps Web をセットアップするための無料チュートリアル [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) が Bogdan Lixandru によって提供されています。
+

--- a/docs/pt/install_setup/synology.md
+++ b/docs/pt/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Configuração do Synology NAS
+
+Para configurar o Gramps Web em um Synology NAS, existe um tutorial gratuito dedicado [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) por Bogdan Lixandru.
+

--- a/docs/ru/install_setup/synology.md
+++ b/docs/ru/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Настройка Synology NAS
+
+Для настройки Gramps Web на Synology NAS существует бесплатное руководство [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) от Bogdan Lixandru.
+

--- a/docs/tr/install_setup/synology.md
+++ b/docs/tr/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS Kurulumu
+
+Gramps Web'i Synology NAS üzerinde kurmak için Bogdan Lixandru tarafından hazırlanan ücretsiz bir rehber mevcuttur: [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/).
+

--- a/docs/uk/install_setup/synology.md
+++ b/docs/uk/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Налаштування Synology NAS
+
+Для налаштування Gramps Web на Synology NAS існує безкоштовний посібник [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) від Bogdan Lixandru.
+

--- a/docs/vi/install_setup/synology.md
+++ b/docs/vi/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Cài đặt Synology NAS
+
+Để cài đặt Gramps Web trên Synology NAS, có một hướng dẫn miễn phí chuyên dụng [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) của Bogdan Lixandru.
+

--- a/docs/zh/install_setup/synology.md
+++ b/docs/zh/install_setup/synology.md
@@ -1,0 +1,4 @@
+# Synology NAS 设置
+
+如需在 Synology NAS 上设置 Gramps Web，可参考 Bogdan Lixandru 提供的免费教程 [How to Install Gramps Web on Your Synology NAS](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/)。
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
           - Docker with Let's Encrypt: install_setup/lets_encrypt.md
           - DigitalOcean: install_setup/digital_ocean.md
           - TrueNAS: install_setup/truenas.md
+          - Synology NAS: install_setup/synology.md
       - Server Administration:
           - User system: install_setup/users.md
           - Server configuration: install_setup/configuration.md
@@ -128,6 +129,7 @@ plugins:
             Docker with Let's Encrypt: Docker mit Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Serververwaltung
             User system: Benutzersystem
             Server configuration: Serverkonfiguration
@@ -191,6 +193,7 @@ plugins:
             Docker with Let's Encrypt: Docker avec Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Administration du serveur
             User system: Système utilisateur
             Server configuration: Configuration du serveur
@@ -254,6 +257,7 @@ plugins:
             Docker with Let's Encrypt: Docker con Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Administración del servidor
             User system: Sistema de usuarios
             Server configuration: Configuración del servidor
@@ -317,6 +321,7 @@ plugins:
             Docker with Let's Encrypt: Docker 与 Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: 服务器管理
             User system: 用户系统
             Server configuration: 服务器配置
@@ -380,6 +385,7 @@ plugins:
             Docker with Let's Encrypt: Docker với Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Quản trị máy chủ
             User system: Hệ thống người dùng
             Server configuration: Cấu hình máy chủ
@@ -443,6 +449,7 @@ plugins:
             Docker with Let's Encrypt: Let's Encrypt ile Docker
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Sunucu Yönetimi
             User system: Kullanıcı sistemi
             Server configuration: Sunucu yapılandırması
@@ -506,6 +513,7 @@ plugins:
             Docker with Let's Encrypt: Docker с Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Администрирование сервера
             User system: Система пользователей
             Server configuration: Конфигурация сервера
@@ -569,6 +577,7 @@ plugins:
             Docker with Let's Encrypt: Docker com Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Administração do servidor
             User system: Sistema de usuários
             Server configuration: Configuração do servidor
@@ -632,6 +641,7 @@ plugins:
             Docker with Let's Encrypt: Let's Encrypt を使用した Docker
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: サーバー管理
             User system: ユーザーシステム
             Server configuration: サーバー設定
@@ -695,6 +705,7 @@ plugins:
             Docker with Let's Encrypt: Docker med Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Serveradministration
             User system: Brugersystem
             Server configuration: Serverkonfiguration
@@ -758,6 +769,7 @@ plugins:
             Docker with Let's Encrypt: Docker Let's Encryptin kanssa
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Palvelinhallinta
             User system: Käyttäjäjärjestelmä
             Server configuration: Palvelinmääritykset
@@ -821,6 +833,7 @@ plugins:
             Docker with Let's Encrypt: Docker con Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Amministrazione del Server
             User system: Sistema utenti
             Server configuration: Configurazione del server
@@ -884,6 +897,7 @@ plugins:
             Docker with Let's Encrypt: Docker з Let's Encrypt
             DigitalOcean: DigitalOcean
             TrueNAS: TrueNAS
+            Synology NAS: Synology NAS
             Server Administration: Адміністрування сервера
             User system: Система користувачів
             Server configuration: Конфігурація сервера


### PR DESCRIPTION
Thanks to Marius Bogdan Lixandru’s [dedicated tutorials](https://mariushosting.com/how-to-install-gramps-web-on-your-synology-nas/) on topics related to self-hosting useful and interesting applications for personal use on your own infrastructure (Synology NAS), I am running for my family a self-hosted Gramps instance on our NAS .

Adding this tutorial  to the documentation at least via a link seems helpful.