### PR TITLE
Add Optional Variable GUNICORN_NUM_WORKERS

### DIFF
--- a/examples/docker-compose-base/docker-compose.yml
+++ b/examples/docker-compose-base/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       GRAMPSWEB_CELERY_CONFIG__broker_url: "redis://grampsweb_redis:6379/0"
       GRAMPSWEB_CELERY_CONFIG__result_backend: "redis://grampsweb_redis:6379/0"
       GRAMPSWEB_RATELIMIT_STORAGE_URI: redis://grampsweb_redis:6379/1
+      # GUNICORN_NUM_WORKERS: 8 # optional variable, each worker increase efficiency, but takes resources (CPU and RAM)
     depends_on:
       - grampsweb_redis
     volumes:

--- a/examples/docker-compose-base/docker-compose.yml
+++ b/examples/docker-compose-base/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       GRAMPSWEB_CELERY_CONFIG__broker_url: "redis://grampsweb_redis:6379/0"
       GRAMPSWEB_CELERY_CONFIG__result_backend: "redis://grampsweb_redis:6379/0"
       GRAMPSWEB_RATELIMIT_STORAGE_URI: redis://grampsweb_redis:6379/1
-      # GUNICORN_NUM_WORKERS: 8 # optional variable, each worker increase efficiency, but takes resources (CPU and RAM)
+      # GUNICORN_NUM_WORKERS: 8 # optional variable, each worker increases efficiency, but takes resources (CPU and RAM)
     depends_on:
       - grampsweb_redis
     volumes:


### PR DESCRIPTION
### Add optional `GUNICORN_NUM_WORKERS` environment variable

This PR introduces support for an optional environment variable `GUNICORN_NUM_WORKERS` for the `grampsweb` service.

#### Motivation
By default, Gunicorn runs with 8 workers, which may reach the resources limit. Allowing users to configure the number of workers enables better utilization of available CPU resources and improves request handling throughput.

#### Changes
- Added support for `GUNICORN_NUM_WORKERS` environment variable
- Documented it as optional in the `docker-compose` configuration
