### PR TITLE
Document navLinks and hideTreeLink frontend config options

### DIFF
--- a/docs/en/install_setup/frontend-config.md
+++ b/docs/en/install_setup/frontend-config.md
@@ -15,9 +15,44 @@ The following option keys exist.
 Key |Type | Description 
 ----|-----|-----------
 `hideDNALink` | boolean | If true, hide the DNA link on the navigation bar.
+`hideTreeLink` | boolean | If true, hide the built-in Family Tree link on the navigation bar.
+`navLinks` | array | Custom links to add to the navigation bar. See [Custom navigation links](#custom-navigation-links) below.
 `hideRegisterLink` | boolean | If true, hide the registration link on the login page. This should be used for multi-tree deployments.
 `loginRedirect` | string | URL to redirect to when not logged in and navigating to any page other than "login" or "register"
 `leafletTileUrl` | string | Custom tile URL for Leaflet maps
 `leafletTileSize` | number | Custom tile size for Leaflet maps
 `leafletZoomOffset` | number | Custom zoom offset for Leaflet maps
 `leafletTileAttribution` | string | Custom attribution for Leaflet maps
+
+## Custom navigation links
+
+The `navLinks` option adds custom links to the main navigation bar, for example to integrate another tool hosted on the same origin or to link to a user manual. It takes an array of objects with the following keys:
+
+Key | Type | Description
+----|------|------------
+`title` | string | The link label shown in the navigation bar (required). It is displayed as entered and is not translated.
+`url` | string | The link target (required). May be a relative path or an absolute URL.
+`icon` | string | Optional SVG path of the icon to display, e.g. one of the paths from [Material Design Icons](https://pictogrammers.com/library/mdi/). Defaults to a generic link icon.
+`target` | string | Optional anchor `target`. Defaults to `_self` (loads the link in the current tab). Use `_blank` to open the link in a new tab.
+
+The default `target` of `_self` matters for links that point to another application served on the **same origin** as Gramps Web (such as a reverse-proxied tool): it ensures the browser performs a real navigation instead of the link being intercepted by the in-app router.
+
+Custom links are added at the end of the main navigation group. To replace the built-in Family Tree link with a custom one, combine `navLinks` with `hideTreeLink`:
+
+```javascript
+window.grampsjsConfig = {
+    hideTreeLink: true,
+    navLinks: [
+        {
+            title: 'Family Tree',
+            url: '/topola'
+        },
+        {
+            title: 'User manual',
+            url: 'https://www.grampsweb.org/',
+            target: '_blank',
+            icon: 'M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'
+        }
+    ]
+}
+```


### PR DESCRIPTION
## Document navLinks and hideTreeLink frontend config options

Companion to gramps-project/gramps-web#1268, which adds two `config.js` options:

- `navLinks` — add custom links to the navigation bar (e.g. a same-origin embedded tool or an external user manual).
- `hideTreeLink` — hide the built-in Family Tree link, so it can be replaced by a custom `navLinks` entry.

Adds both to the options table in `frontend-config.md` plus a *Custom navigation links* section covering the per-link keys and the `target: '_self'` default (needed so same-origin links trigger a real navigation rather than being intercepted by the in-app router).

Should merge together with / after the code PR, since the documented options don't exist until it lands.