### PR TITLE
Add comments for Traefik configuration in docker-compose

### DIFF
--- a/examples/docker-compose-base/docker-compose.yml
+++ b/examples/docker-compose-base/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - grampsweb
       - grampsweb_redis
     command: celery -A gramps_webapi.celery worker --loglevel=INFO --concurrency=2
+    # If using Traefik as a reverse proxy, uncomment the labels line.  This prevents carrying over the grampsweb container labels into the celery container
+    # causing a load balancer issue between the main grampsweb container and the celery container:
+  # labels: []
 
   grampsweb_redis:
     image: docker.io/valkey/valkey:8-alpine


### PR DESCRIPTION
Have run into and seen others run into issues with the template container for celery configuration when using traefik.  Added a commented labels line to potentially add in for traefik users.  Thought it was more appropriate with the main example as traefik configurations can vary wildly, but most often use labels in the compose file to get traefik to auto-recognize in docker.  

If this needs to be a separate example/caveat, let me know.  